### PR TITLE
Changing the default connection ports for nodes + RPC ports (MAINNET …

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -42,7 +42,7 @@ void ThreadRPCServer3(void* parg);
 
 static inline unsigned short GetDefaultRPCPort()
 {
-    return GetBoolArg("-testnet", false) ? 21198 : 11198;
+    return GetBoolArg("-testnet", false) ? 49329 : 49349; // Port MICTN(MIC TEST RPC) : Port MICMN(MIC MAIN RPC)
 }
 
 Object JSONRPCError(int code, const string& message)

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -18,7 +18,7 @@
 extern bool fTestNet;
 static inline unsigned short GetDefaultPort(const bool testnet = fTestNet)
 {
-   return testnet ? 22299 : 11199;
+   return testnet ? 49325 : 49345; // Port MICTN(MIC TEST NODE) : Port MICMN(MIC MAIN NODE)
 }
 
 


### PR DESCRIPTION
…and TESTNET)

The changes made are intended to reduce the number of existing conflicts with other wallets and/or programs that use the current ports by default.
The number of each door refers to the number of this letter in the alphabet, according to the numerological correspondence calculation.
M = 4
I = 9
C = 3
M(ain) = 4
N(ode) = 5